### PR TITLE
Hotfix - Sort table by date instead of database ID

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -681,7 +681,7 @@ void MainWindow::reset_table_sort() {
      * Reset table sort to default, by datetime descending.
      */
 
-    ui->drinkLogTable->sortItems(9, Qt::DescendingOrder);
+    ui->drinkLogTable->sortItems(0, Qt::DescendingOrder);
 }
 
 double MainWindow::update_oz_alcohol_consumed_this_week(const std::vector<Beer>& beers_this_week) {


### PR DESCRIPTION
## Description
Currently, the table sorts by the database ID. This is fine when users enter beers linearly. However, if a user enters beers with out of order dates, the sorting will be broken. This PR sorts by date instead of ID so that the sorting will be correct.

## Motivation and Context
This change is required to sort correctly. It better delivers information to users.

## How Has This Been Tested?
This has been tested by inserting rows with various dates and checking the sorting. This has been tested on Beertabs-v0.8.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
