### PR TITLE
Reset date and notes when user clicks the Clear button

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -160,7 +160,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->breweryInput, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(brewery_input_changed(const QString&)));
 
     // Update fields to match beer that comes first alphabetically
-    update_fields_on_beer_name();
+    reset_fields();
 }
 
 MainWindow::~MainWindow()
@@ -245,10 +245,20 @@ void MainWindow::reset_fields() {
      * Clear user entry fields and table selection for entering a new beer.
      */
 
+    std::string notes;
+
     std::cout << "clearing fields" << std::endl;
     ui->drinkLogTable->clearSelection();
     update_beer_fields();
     update_fields_on_beer_name();
+
+    // Set notes to the notes for beer in the name input
+    notes = get_latest_notes_for_beer(ui->nameInput->currentText().toStdString());
+    ui->notesInput->setText(QString::fromStdString(notes));
+
+    // Set datepicker to today's date
+    QDate todays_date = QDate::currentDate();
+    ui->drinkDateInput->setDate(todays_date);
 }
 
 void MainWindow::update_table() {
@@ -333,18 +343,7 @@ void MainWindow::populate_fields(const QItemSelection &, const QItemSelection &)
 
         Beer beer = Database::read_row(row_to_get, storage);
 
-        // Get latest notes entered for the selected beer
-        std::vector<Beer> beers_by_name = Database::filter("Name", beer.name, storage);
-        unsigned temp_id = 0;
-        std::string notes;
-        for (const auto& beer_for_notes : beers_by_name) {
-            if (beer_for_notes.id > temp_id) {
-                temp_id = beer_for_notes.id;
-                if (!beer_for_notes.notes.empty()) {
-                    notes = beer_for_notes.notes;
-                }
-            }
-        }
+        std::string notes = get_latest_notes_for_beer(beer.name);
 
         std::ostringstream month_padded;
         std::ostringstream day_padded;
@@ -884,4 +883,28 @@ void MainWindow::update_favorite_type() {
 
     std::string fave_type = Calculate::favorite_type(storage);
     ui->favoriteTypeOutput->setText(QString::fromStdString(fave_type));
+}
+
+std::string MainWindow::get_latest_notes_for_beer(const std::string& name) {
+    /*
+     * Get the latest entered notes for a specific beer.
+     * @param name: The name to retrieve the notes for.
+     * @return notes: String containing beer notes.
+     */
+
+    std::string notes;
+
+    // Get latest notes entered for the selected beer
+    std::vector<Beer> beers_by_name = Database::filter("Name", name, storage);
+    unsigned temp_id = 0;
+    for (const auto& beer_for_notes : beers_by_name) {
+        if (beer_for_notes.id > temp_id) {
+            temp_id = beer_for_notes.id;
+            if (!beer_for_notes.notes.empty()) {
+                notes = beer_for_notes.notes;
+            }
+        }
+    }
+
+    return notes;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -37,6 +37,7 @@ private:
     void update_mean_abv();
     void update_mean_ibu();
     void update_fields_on_beer_name();
+    std::string get_latest_notes_for_beer(const std::string& name);
 
 private slots:
     void submit_button_clicked();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added code to reset the date input to today's date when user clicks the Clear button. Also moved the notes retrieval code to its own method and implemented it in the reset_fields() method, as well as its original location. 

## Motivation and Context
This change was required to have correct Clear functionality. Now, users don't have to browse back to today's date when clicking the clear button. The notes are also updated with whichever beer is selected when users click the Clear button.
This fixes issue #159.

## How Has This Been Tested?
This has been tested by running the app, selected a previously-entered beer, and clicking the Clear button. The app behaves as expected. on macOS 10.15.6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
