### PR TITLE
Update notes when user changes the name, type, or brewery fields

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -880,6 +880,11 @@ void MainWindow::update_fields_on_beer_name() {
         ui->sizeInput->setValue(size);
         ui->ratingInput->setValue(rating);
     }
+
+    // Set notes to the notes for beer in the name input
+    std::string notes;
+    notes = get_latest_notes_for_beer(ui->nameInput->currentText().toStdString());
+    ui->notesInput->setText(QString::fromStdString(notes));
 }
 
 void MainWindow::update_favorite_type() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Call `get_latest_notes_for_beer()` when changing name, brewery, or type so that the notes field is updated to reflect the newly-selected beer name.

## Motivation and Context
This fixes an issue where the beer notes weren't updated when changing the input fields.
This closes issue #165.

## How Has This Been Tested?
This has been tested by opening the app and changing the name, type, and brewery fields.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
